### PR TITLE
Fixed empty title metadata.

### DIFF
--- a/formMain.cs
+++ b/formMain.cs
@@ -245,6 +245,10 @@ namespace MasterOfWebM
             {
                 baseCommand = baseCommand.Replace("{metadata}", string.Format("-metadata title=\"{0}\"", txtTitle.Text.Replace("\"", "\\\"")));
             }
+            else
+            {
+                baseCommand = baseCommand.Replace("{metadata}", "");
+            }
 
             // If everything is valid, continue with the conversion
             if (verified)


### PR DESCRIPTION
Without this fix in case of empty Title {metadata} tag is not replaced in baseCommand. Because of that invalid command is executed and results in FileNotFoundException. Example of bad commend: 'ffmpeg -y -i "O:\input.mp4" -ss 20 -t 5 -c:v libvpx -b:v 4915K -threads 4 {metadata} -quality best -auto-alt-ref 1 -lag-in-frames 16 -slices 8 -an -pass 1 -f webm NUL'.